### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/open-pr-on-pact-change.yml
+++ b/.github/workflows/open-pr-on-pact-change.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'pacts/BundesligaFrontend-BundesligaBackend.json'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fork_and_pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/atruvia/bundesliga-tabelle-ui/security/code-scanning/1](https://github.com/atruvia/bundesliga-tabelle-ui/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: write` to push changes to the forked repository.
- `pull-requests: write` to create a pull request.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` is restricted to the specified permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
